### PR TITLE
Fix/m4 67 card overflow effectmangement

### DIFF
--- a/resources/views/components/component-effect-card.blade.php
+++ b/resources/views/components/component-effect-card.blade.php
@@ -1,5 +1,5 @@
 <div class="w-full md:w-1/2 px-2 my-2">
-    <div class="bg-white shadow-md rounded-lg p-6 max-h-[30vh] overflow-auto">
+    <div class="bg-white shadow-md rounded-lg p-6 overflow-auto">
         <h1 class="text-2xl font-bold mb-4">{{ $simComponent->name }}</h1>
         <x-table>
             <x-slot:thead>


### PR DESCRIPTION
fixed the issue that the effect mangement card overflowed and made it so that you needed to scroll in each card.